### PR TITLE
Hopefully fix timing

### DIFF
--- a/lethe.js
+++ b/lethe.js
@@ -498,10 +498,11 @@ function play(video) {
       playStopped(); // skip to next video
     });
 
-    currentStream.on('end', () => setTimeout(playStopped, Config.timeOffset || 8000)); // 8 second leeway for bad timing
+    //currentStream.on('end', () => setTimeout(playStopped, Config.timeOffset || 8000)); // 8 second leeway for bad timing, this caused bad timing
     connection.playRawStream(currentStream).then(intent => {
       boundChannel.sendMessage(`Playing ${video.prettyPrint()}`);
       client.setStatus('online', video.title);
+      intent.on('end', this.playStopped);
     });
   }
 }

--- a/lethe.js
+++ b/lethe.js
@@ -502,7 +502,9 @@ function play(video) {
     connection.playRawStream(currentStream).then(intent => {
       boundChannel.sendMessage(`Playing ${video.prettyPrint()}`);
       client.setStatus('online', video.title);
-      intent.on('end', this.playStopped);
+      intent.on('end', ()=>{
+        playStopped();
+      });
     });
   }
 }


### PR DESCRIPTION
Even playing around with the offset value in the config I could never get it to end on the actual end of the song. This PR is an attempt to fix the issue that caused the need for an offset.

Instead of ending when the streambuffer is consumed playing a song shoud now end when discord.js finishes playing it.
